### PR TITLE
fixed react-native@0.59 compatibility

### DIFF
--- a/src/NavigatorNavigationBar.js
+++ b/src/NavigatorNavigationBar.js
@@ -141,7 +141,12 @@ class NavigatorNavigationBar extends React.Component {
       var props = this._getReusableProps(componentName, index);
       if (component && interpolate[componentName](props.style, amount)) {
         props.pointerEvents = props.style.opacity === 0 ? 'none' : 'box-none';
-        component.setNativeProps(props);
+        if(!isNaN(props.style.left)){
+          component.setNativeProps(props);
+        } else {
+          const {left, ...otherStyle} = props.style;
+          component.setNativeProps({...props, style: otherStyle});
+        }
       }
     }, this);
   };


### PR DESCRIPTION
fixed RN 0.59 compatibility bug 
```
E/ReactNativeJS: [107,"RCTView",{"opacity":1,"left":"<<NaN>>","pointerEvents":"box-none"}] is not usable as a native method argument
E/unknown:ReactNative: Exception in native call
    com.facebook.jni.CppException: Malformed calls from JS: field sizes are different.
```